### PR TITLE
fix: error from session list if it is empty

### DIFF
--- a/lua/tabline/cmds.lua
+++ b/lua/tabline/cmds.lua
@@ -582,7 +582,7 @@ local function filter(bang, arg) -- Apply filter for bufferline {{{1
 end
 
 local function persist(bang) -- Enable or disable persistance for session {{{1
-  if not vim.v.this_session then
+  if vim.v.this_session == "" then
     print("Not in a session.")
     g.persist = nil
     return

--- a/lua/tabline/fzf/sessions.lua
+++ b/lua/tabline/fzf/sessions.lua
@@ -74,10 +74,13 @@ local function sessions_list()
     end
   end
 
-  if not winOs and #sessions > 0 then
-    table.sort(sessions, function(a,b) return lastmod(a) < lastmod(b) end)
+  if #sessions > 1 then
+    local this_session = table.remove(sessions, tbl.index(sessions, vim.v.this_session))
+    if not winOs then
+      table.sort(sessions, function(a,b) return lastmod(a) < lastmod(b) end)
+    end
+    table.insert(sessions, this_session)
   end
-  table.insert(sessions, table.remove(sessions, tbl.index(sessions, vim.v.this_session)))
 
   for _, ss in ipairs(sessions) do
     table.insert(lines, 1, desc(ss, fn.fnamemodify(ss, ':t'), data))


### PR DESCRIPTION
If there are no sessions yet, `session load` and `session delete` will throw an error. I fixed it by this PR. 
Thank you.