### PR TITLE
fix: fzf icon error

### DIFF
--- a/lua/tabline/render/icons.lua
+++ b/lua/tabline/render/icons.lua
@@ -16,7 +16,7 @@ if not ok then
   icons = nil
 else
   icons = icons.get_icons()
-  icons.fzf = { icon = "🗲", color = "#d0bf41", cterm_color = "185", name = 'fzf' }
+  icons.fzf = { icon = "", color = "#d0bf41", cterm_color = "185", name = 'fzf' }
   icons.python = { icon = "", color = "#3572A5", cterm_color = "67", name = 'python' }
   icons.default = { icon = "", color = "#6d8086", cterm_color = "66", name = "default" }
 end


### PR DESCRIPTION
I noticed an error for the fzf icon. It seems the icon is missing in the latest nerd font. 

<img width="294" alt="image" src="https://github.com/mg979/tabline.nvim/assets/11582667/18d9560d-299e-4a31-8e93-37ce8d93aaed">

I am now using `JetbrainsMono` patched nerd font v3 (this is a huge update for nerd font and it deprecated many old icons and re-name icons from material design). I also tested it with the other fonts (Hack, Cascadia and InputMono) patched nerd font v3 and v2.3.3 (the latest version before v3). The icon couldn't be displayed normally in all my tests.

In this PR, I replaced the icon with `nf-cod-search`, i.e., ``.

<img width="195" alt="image" src="https://github.com/mg979/tabline.nvim/assets/11582667/faaaa758-7c4b-42e3-8d79-b1c4aba3f2af">

Thank you. 