### PR TITLE
feat: make the layout of fzf window configurable

### DIFF
--- a/config
+++ b/config
@@ -46,6 +46,7 @@ local settings = {
   ascii_only                = false,
   scratch_label             = '[Scratch]',
   unnamed_label             = '[Unnamed]',
+  fzf_layout                = { down = '30%' },
 }
 
 

--- a/doc/tabline-nvim.txt
+++ b/doc/tabline-nvim.txt
@@ -110,6 +110,7 @@ initialized. For the default value, run `:Tabline config`
   |icon_spacing|          spaces between icon and filename (default '  ')
   |separators|            for active and inactive tabs/buffers
   |sessions_dir|          directory for the session management commands
+  |fzf_layout|            see below
 
 
   |modes|        {table}
@@ -139,6 +140,13 @@ initialized. For the default value, run `:Tabline config`
                (with a different color in tabs and buffers mode).
                Also as table: `{ buffers = 'bufnr' }` will use 'bufnr' in
                buffers mode, 'sep' (default value) for other modes.
+
+  |fzf_layout|   {table}
+               Determines the size and position of fzf window.
+               Same as `g:fzf_layout` in `fzf.vim`.
+               For example: `{ down = '30%' }` or
+               `{ window = { width = 0.9, height = 0.6 } }` for popup window
+               Reference: https://github.com/junegunn/fzf/blob/master/README-VIM.md
 
 
 

--- a/lua/tabline/fzf/fzf.lua
+++ b/lua/tabline/fzf/fzf.lua
@@ -3,6 +3,7 @@ if vim.fn.exists('g:loaded_fzf') == 0 then
 end
 
 local a = require'tabline.fzf.ansi'
+local c = require'tabline.setup'.settings
 
 -- vim functions {{{1
 local fn = vim.fn
@@ -132,25 +133,23 @@ end
 
 local function list_buffers()
   statusline("Open Buffer")
-  fn['fzf#run']({
-      source = tab_buffers(),
-      sink = function(line)
-        local _,_,b = string.find(line, '^%s*%[(%d+)%]')
-        execute('b ' .. b)
-      end,
-      down = '30%',
-      options = '--ansi --header-lines=1 --no-preview'
-    })
+  fn['fzf#run'](vim.tbl_deep_extend('force', {
+    source = tab_buffers(),
+    sink = function(line)
+      local _,_,b = string.find(line, '^%s*%[(%d+)%]')
+      execute('b ' .. b)
+    end,
+    options = '--ansi --header-lines=1 --no-preview'
+  }, c.fzf_layout))
 end
 
 local function closed_tabs()
   statusline("Reopen Tab")
-  fn['fzf#run']({
-      source = closed_tabs_list(),
-      sink = tabreopen,
-      down = '30%',
-      options = '--ansi --header-lines=1 --no-preview'
-    })
+  fn['fzf#run'](vim.tbl_deep_extend('force', {
+    source = closed_tabs_list(),
+    sink = tabreopen,
+    options = '--ansi --header-lines=1 --no-preview'
+  }, c.fzf_layout))
 end
 
 local function load_session()
@@ -158,24 +157,22 @@ local function load_session()
   statusline("Load Session")
   local curloaded, sessions = require'tabline.fzf.sessions'.sessions_list()
   local options = '--ansi --no-preview --header-lines=' .. (curloaded and '2' or '1')
-  fn['fzf#run']({
-      source = sessions,
-      sink = require'tabline.fzf.sessions'.session_load,
-      down = '30%',
-      options = options,
-    })
+  fn['fzf#run'](vim.tbl_deep_extend('force', {
+    source = sessions,
+    sink = require'tabline.fzf.sessions'.session_load,
+    options = options,
+  }, c.fzf_layout))
 end
 
 local function delete_session()
   if mac_no_gnu() or no_sessions() then return end
   statusline("Delete Session")
   local _, sessions = require'tabline.fzf.sessions'.sessions_list()
-  fn['fzf#run']({
-      source = sessions,
-      sink = require'tabline.fzf.sessions'.session_delete,
-      down = '30%',
-      options = '--ansi --header-lines=1 --no-preview'
-    })
+  fn['fzf#run'](vim.tbl_deep_extend('force', {
+    source = sessions,
+    sink = require'tabline.fzf.sessions'.session_delete,
+    options = '--ansi --header-lines=1 --no-preview'
+  }, c.fzf_layout))
 end
 
 return {

--- a/lua/tabline/setup.lua
+++ b/lua/tabline/setup.lua
@@ -44,6 +44,7 @@ M.settings = {  -- user settings {{{1
   colored_icons = true,
   icon_spacing = '  ',
   separators = {'▎', '▏'},
+  fzf_layout = { down = '30%' },
 }
 
 M.icons = { -- icons {{{1


### PR DESCRIPTION
This PR adds a new option `fzf_layout` to configure the size and position of the fzf window. It's the same with `g:fzf_layout` in [fzf.vim](https://github.com/junegunn/fzf/blob/master/README-VIM.md#examples).

```lua
fzf_layout = { down = '30%' } -- default

-- Use a popup/floating window
fzf_layout = { window = { width = 0.8, height = 0.8 } }
```

Thank you. 