### PR TITLE
fix: reset persistance

### DIFF
--- a/lua/tabline/cmds.lua
+++ b/lua/tabline/cmds.lua
@@ -588,6 +588,7 @@ local function persist(bang) -- Enable or disable persistance for session {{{1
     return
   end
   if bang then
+    g.persist = nil
     pers.disable_persistance()
   else
     g.persist = vim.v.this_session

--- a/lua/tabline/persist.lua
+++ b/lua/tabline/persist.lua
@@ -55,6 +55,10 @@ function M.restore_persistance()
     g.persist = vim.v.this_session
     -- must update also session file
     M.update_persistance()
+  else
+    -- If the session to be loaded has persistance disabled, reset the
+    -- persistance.
+    g.persist = nil
   end
 end
 
@@ -115,7 +119,6 @@ end
 
 --- Disable persistance and revert changes to session file.
 function M.disable_persistance()
-  g.persist = nil
   M.remove_persistance()
 end
 


### PR DESCRIPTION
I see, from the doc, the persistance status is kept **per session**.

1. Session load
If we are already in the session with persistance enabled, then we load another session with no persistance, the persistance should be off.

2. Session delete
If the deleted session is the current session and it has persistance enabled, the persistance status should be off.

3. `update_current_session()`
This is function are called in both `session_load` and `session_save` to update the current session which will be replaced by new loaded/saved session. It uses `mksession!` to overwrite the current session file, but `let g:tnv_persist xxx` will be deleted from the file, i.e., the persistance status will be lost.

    I noticed that `update_current_session()` was implemented two year ago when the persistance feature was not born. Now, we can use `update_persistance()` function instead to update the current session and meanwhile maintain the persistance.

This PR fixes these three bugs and it works well. Please check. Thank you very much.